### PR TITLE
Use new graphql filter syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ The logic is as follows:
 
 ## Requirements
 
-* An OpenCTI instance up and running
+* An OpenCTI instance (version 5.12 or higher) up and running
+  * Older versions are supported, but you need to revert the changes in #11 in
+	 order to support the older graphql filter syntax.
 * A read-only OpenCTI API token suitable for querying data (*Access knowledge*
   \+ *Access exploration*(?))
 


### PR DESCRIPTION
StixCyberObservablesFiltering and IndicatorsFiltering no longer exist and are replaced by FilterGroup. More information here: https://docs.opencti.io/latest/reference/filters-migration/

Resolves #9.