### PR TITLE
Use filter mode 'and' for stix pattern type + values

### DIFF
--- a/custom-opencti.py
+++ b/custom-opencti.py
@@ -545,14 +545,14 @@ def query_opencti(alert, url, token):
                     'obs': {
                         "mode": "or",
                         "filterGroups": [],
-                        "filters": [{'key': filter_key, 'values': filter_values}]
+                        "filters": [{"key": filter_key, "values": filter_values}]
                     },
                     'ind': {
-                        "mode": "or",
+                        "mode": "and",
                         "filterGroups": [],
                         "filters": [
-                            {'key': 'pattern_type', 'values': ['stix']},
-                            {'key': 'pattern', 'values': ind_filter},
+                            {"key": "pattern_type", "values": ["stix"]},
+                            {"mode": "or", "key": "pattern", "values": ind_filter},
                         ]
                     }
                     }}


### PR DESCRIPTION
When converting to the new filter syntax, an incorrect mode was used for the indicator filter. Now the stix pattern type must match along with the values queried.